### PR TITLE
Build win32 installer

### DIFF
--- a/.github/workflows/pyinstaller_windows.yml
+++ b/.github/workflows/pyinstaller_windows.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install pyinstaller==4.1
+        pip install pyinstaller==4.2
         pip install -r requirements.txt
     - name: build with pyinstaller
       run: |

--- a/.github/workflows/pyinstaller_windows.yml
+++ b/.github/workflows/pyinstaller_windows.yml
@@ -42,10 +42,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-      - name: Download installer artifact
+      - name: Download installer artifacts
         uses: actions/download-artifact@v2
-        with:
-          name: installer
       - name: List files
         run: |
           ls -l
@@ -59,13 +57,23 @@ jobs:
           release_name: Release ${{ github.ref }}
           draft: false
           prerelease: false
-      - name: Upload Release Asset
+      - name: Upload x64 binary
         id: upload-release-asset
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: Install Battery tester PX100.exe
-          asset_name: Battery-Tester-PX100.exe
+          asset_path: Battery-Tester-PX100-x64.exe
+          asset_name: Battery-Tester-PX100-x64.exe
+          asset_content_type: application/exe
+      - name: Upload win32 binary
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: Battery-Tester-PX100-x86.exe
+          asset_name: Battery-Tester-PX100-x86.exe
           asset_content_type: application/exe

--- a/.github/workflows/pyinstaller_windows.yml
+++ b/.github/workflows/pyinstaller_windows.yml
@@ -6,6 +6,9 @@ jobs:
   build:
     name: Build windows installer
     runs-on: windows-latest
+    strategy:
+      matrix:
+        python_arch: [ x64, x86 ]
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
@@ -13,6 +16,7 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: 3.8
+        architecture: ${{ matrix.python_arch }}
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -24,12 +28,12 @@ jobs:
     - name: Build NSIS installer package
       run: |
         makensis -VERSION
-        makensis px100.nsi
+        makensis "/XOutFile Battery-Tester-PX100-${{matrix.python_arch}}.exe" px100.nsi
     - name: Upload installer artifact
       uses: actions/upload-artifact@v2
       with:
-        name: installer
-        path: Install*
+        name: installer${{matrix.python_arch}}
+        path: Battery-Tester*
   release:
     name: Prepare a release
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ See the [v2.70 binary Protocol description](protocol_PX-100_2_70.md)
 
 An installer can be downloaded from the [releases section](https://github.com/misdoro/Electronic_load_px100/releases/latest)
 
+Please use -x86.exe if you are running 32-bit windows.
+
 ## Linux / macOS
 
 Python is required to run this software. Version 3.6 or newer is required.

--- a/px100.nsi
+++ b/px100.nsi
@@ -5,7 +5,6 @@ Basic installer for battery tester
 !define NAME "Battery tester PX100"
 !define REGPATH_UNINSTSUBKEY "Software\Microsoft\Windows\CurrentVersion\Uninstall\${NAME}"
 Name "${NAME}"
-OutFile "Install ${NAME}.exe"
 Unicode True
 RequestExecutionLevel User ; We don't need UAC elevation
 InstallDir "" ; Don't set a default $InstDir so we can detect /D= and InstallDirRegKey


### PR DESCRIPTION
Fixes #8.

Install 32-bit python environment in a separate actions job, that triggers installing 32-bit dependencies and eventually builds 32-bit executable.

Release 0.1.2 updated with a binary from this pipeline.