### PR TITLE
Clean up console output

### DIFF
--- a/data_store.py
+++ b/data_store.py
@@ -17,7 +17,10 @@ class DataStore:
         self.data = DataFrame()
 
     def append(self, row):
-        print(row)
+        tnow = datetime.now().isoformat(sep= ' ', timespec='milliseconds')
+        print(f"{tnow} time_running={row['time']} is_on={row['is_on']} v={row['voltage']:.3f} i={row['current']:.3f}" \
+            f" Ah={row['cap_ah']:.2f} board_temp={row['temp']} i_setpoint={row['set_current']}" \
+            f" v_setpoint={row['set_voltage']} timer_setpoint={row['set_timer']}")
         self.lastrow = row
         # self.data = self.data.append(row, ignore_index=True)
         new_row_df = DataFrame([row])

--- a/data_store.py
+++ b/data_store.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from os import path
 
 from pandas import DataFrame
+import pandas as pd
 
 
 class DataStore:
@@ -18,7 +19,9 @@ class DataStore:
     def append(self, row):
         print(row)
         self.lastrow = row
-        self.data = self.data.append(row, ignore_index=True)
+        # self.data = self.data.append(row, ignore_index=True)
+        new_row_df = DataFrame([row])
+        self.data = pd.concat([self.data, new_row_df], ignore_index=True)
 
     def write(self, basedir, prefix):
         filename = "{}_raw_{}.csv".format(prefix, datetime.now().strftime("%Y%m%d_%H%M%S"))

--- a/instruments/px100.py
+++ b/instruments/px100.py
@@ -122,7 +122,6 @@ class PX100(Instrument):
         return self.__is_number(self.getVal(PX100.VOLTAGE))
 
     def readAll(self, read_all_aux=False):
-        print("readAll")
         self.__clear_device()
         self.update_vals(PX100.FREQ_VALS)
 


### PR DESCRIPTION
- Use `pd.concat()` due suppress deprecation warning
- Format data printed to console
- Remove extraneous print statement()